### PR TITLE
conf/layer.conf: Remove dependancy on yoctobsp

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,6 @@ BBFILE_PATTERN_meta-freertos = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-freertos = "6"
 
 LAYERDEPENDS_meta-freertos = "core"
-LAYERDEPENDS_meta-freertos += "yoctobsp"
 
 LAYERSERIES_COMPAT_meta-freertos = "honister dunfell"
 


### PR DESCRIPTION
There doesn't seem to be an actual need for a LAYERDEPENDS for yoctobsp.
In fact, if you don't base on a distro with yoctobsp, this causes
issues.

Signed-off-by: Eilís Ní Fhlannagáin <elizabeth.flanagan@huawei.com>