### PR TITLE
Deprecate git protocol on GitHub SRC_URI entries

### DIFF
--- a/classes/freertos-armv5.bbclass
+++ b/classes/freertos-armv5.bbclass
@@ -12,7 +12,7 @@ inherit freertos-image
 BSP_REPO ?= "../bsp"
 
 SRC_URI:append = " \
-    git://github.com/aehs29/FreeRTOS-GCC-ARM926ejs.git;name=bsp;destsuffix=bsp;branch=aehs29/bsp; \
+    git://github.com/aehs29/FreeRTOS-GCC-ARM926ejs.git;name=bsp;destsuffix=bsp;branch=aehs29/bsp;protocol=https \
 "
 
 # BSP repo License

--- a/classes/freertos-image.bbclass
+++ b/classes/freertos-image.bbclass
@@ -24,7 +24,7 @@ LIC_FILES_CHKSUM = "file://../freertos/LICENSE;md5=7ae2be7fb1637141840314b51970a
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = " \
-    gitsm://github.com/FreeRTOS/FreeRTOS-LTS.git;name=freertos;destsuffix=freertos;branch=${SRCBRANCH} \
+    gitsm://github.com/FreeRTOS/FreeRTOS-LTS.git;name=freertos;destsuffix=freertos;branch=${SRCBRANCH};protocol=https \
 "
 
 SRCREV_FORMAT ?= "freertos_bsp"

--- a/recipes-freertos/freertos-demo/freertos-demo_git.bb
+++ b/recipes-freertos/freertos-demo/freertos-demo_git.bb
@@ -4,7 +4,7 @@ inherit freertos-armv5
 
 # App can be replaced by using a different repo
 SRC_URI += " \
-    git://github.com/aehs29/FreeRTOS-GCC-ARM926ejs.git;name=app;destsuffix=app;branch=aehs29/application; \
+    git://github.com/aehs29/FreeRTOS-GCC-ARM926ejs.git;name=app;destsuffix=app;branch=aehs29/application;protocol=https \
     file://use-newlib-as-libc.patch \
 "
 


### PR DESCRIPTION
These patches fix build warnings regarding the GitHub git protocol deprecation.