### PR TITLE
[kirkstone] freertos.conf: Drop BB_DANGLINGAPPENDS_WARNONLY

### DIFF
--- a/conf/distro/freertos.conf
+++ b/conf/distro/freertos.conf
@@ -7,7 +7,5 @@ TCLIBCAPPEND = ""
 
 #INHIBIT_SYSROOT_STRIP="1"
 
-BB_DANGLINGAPPENDS_WARNONLY = "1"
-
 INHERIT += "uninative"
 require conf/distro/include/yocto-uninative.inc

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PRIORITY_meta-freertos = "6"
 
 LAYERDEPENDS_meta-freertos = "core"
 
-LAYERSERIES_COMPAT_meta-freertos = "honister dunfell"
+LAYERSERIES_COMPAT_meta-freertos = "kirkstone honister dunfell"
 
 
 # Uncomment the following to enable the default multiconfig build


### PR DESCRIPTION
BB_DANGLINGAPPENDS_WARNONLY changes parsing behaviour when using the
freertos distro configuration. This is generally undesirable as it can
break downstream projects' assumptions on how to handle bbappends. Let's
drop it and we can handle this with greater granularity using dynamic
layers (if needed at all).